### PR TITLE
fix: enable v1beta API version for Gemini 3.0 preview support

### DIFF
--- a/src/backend/managers/modelManager.ts
+++ b/src/backend/managers/modelManager.ts
@@ -26,11 +26,11 @@ export class ModelManager {
       streaming: true, // DEFAULT
       apiKey: providerApiKey,
       safetySettings: [
-        {category: HarmCategory.HARM_CATEGORY_HARASSMENT, threshold: HarmBlockThreshold.BLOCK_NONE},
-        {category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT, threshold: HarmBlockThreshold.BLOCK_NONE},
-        {category: HarmCategory.HARM_CATEGORY_CIVIC_INTEGRITY, threshold: HarmBlockThreshold.BLOCK_NONE},
-        {category: HarmCategory.HARM_CATEGORY_HATE_SPEECH, threshold: HarmBlockThreshold.BLOCK_NONE},
-        {category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT, threshold: HarmBlockThreshold.BLOCK_NONE},
+        { category: HarmCategory.HARM_CATEGORY_HARASSMENT, threshold: HarmBlockThreshold.BLOCK_NONE },
+        { category: HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT, threshold: HarmBlockThreshold.BLOCK_NONE },
+        { category: HarmCategory.HARM_CATEGORY_CIVIC_INTEGRITY, threshold: HarmBlockThreshold.BLOCK_NONE },
+        { category: HarmCategory.HARM_CATEGORY_HATE_SPEECH, threshold: HarmBlockThreshold.BLOCK_NONE },
+        { category: HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT, threshold: HarmBlockThreshold.BLOCK_NONE },
       ]
     }
     return config
@@ -42,7 +42,7 @@ export class ModelManager {
 
     // Search the selected model on the model list 
     const model = allAvailableModels.find(m => m.name === settings.model)!;
-    
+
     // Configure the model depending on the provider
     const config: ModelConfig = this.getModelConfig(model);
 
@@ -52,6 +52,7 @@ export class ModelManager {
       apiKey: config.apiKey,
       streaming: config.streaming,
       safetySettings: config.safetySettings,
+      apiVersion: "v1beta",
     });
   }
 }


### PR DESCRIPTION
## Overview

Fixed an API error that occurred when using the Google Gemini 3.0 Preview model (`gemini-3-pro-preview`).

## Changes

- Added `apiVersion: "v1beta"` to the initialization configuration of `ChatGoogleGenerativeAI` in the `ModelManager` class.

## Reason

Preview and Experimental models are sometimes only provided via the `v1beta` endpoint of the Google Generative AI API, rather than `v1stable`. Therefore, it is necessary to explicitly specify the API version.

## Verification

- Verified that the application operates without errors when `gemini-3-pro-preview` is selected in the settings.